### PR TITLE
Dealer locator alphabetical sort and Pin issue

### DIFF
--- a/blocks/dealer-locator/dealer-locator.css
+++ b/blocks/dealer-locator/dealer-locator.css
@@ -1857,7 +1857,8 @@ main .section.dealer-locator-container > div {
 .dealer-locator .sidebar .panel-card .panel-container {
     display: block;
     width: 100%;
-    position: relative
+    position: relative;
+    cursor: pointer;
 }
 
 .dealer-locator .sidebar .panel-card .panel-container ul {

--- a/blocks/dealer-locator/sidebar-maps.js
+++ b/blocks/dealer-locator/sidebar-maps.js
@@ -1569,6 +1569,9 @@ $.fn.tmpPins = function (tmpPinList) {
     $("<div/>", {
       'html': templateClone,
       'click': function () {
+        // look into a child element with class teaser-top and get the data-id attribute
+        var id = $(this).find('.teaser-top').attr('data-id');
+        $.fn.switchSidebarPane('sidebar-pin', id);
       },
       'mouseenter': function () {
 

--- a/blocks/dealer-locator/sidebar-maps.js
+++ b/blocks/dealer-locator/sidebar-maps.js
@@ -92,7 +92,7 @@ var uptimeClicked = false;
 $electricDealer = false;
 $hoverText = $('#hoverText').val();
 $country = window.locatorConfig.country;
-var isLocationOFF = false;
+var isLocationOFF = true;
 
 // Google callback letting us know maps is ready to be used
 (function () {
@@ -2407,7 +2407,7 @@ $.fn.setLocation = function (e) {
   if (navigator.geolocation) {
 
     navigator.geolocation.getCurrentPosition(function (position) {
-
+      isLocationOFF = false;
       var pos = {
         lat: position.coords.latitude,
         lng: position.coords.longitude

--- a/blocks/dealer-locator/sidebar-maps.js
+++ b/blocks/dealer-locator/sidebar-maps.js
@@ -104,7 +104,7 @@ var isLocationOFF = false;
         lat: defaultCenterCoords.lat,
         lng: defaultCenterCoords.lng
       },
-      zoom: 4,
+      zoom: 8,
       mapTypeControl: false,
       streetViewControl: false,
       fullscreenControl: false,


### PR DESCRIPTION
# Fixes

- If the user has not chosen to allow or block or choose to block the geolocation, the sidebar is sorted alphabetically
- If the user chooses to allow it, then is sorted by distance

### Other fixes

now, all the dealers' cards in the sidebar can open the dealers' info to avoid a bug that keeps the pin zoomed in the map if the user clicks out of a specific zone in the card, e.g, over the pin's icon or just below of it

#

Test URLs:
- Before: https://main--vg-macktrucks-com-au--hlxsites.hlx.page/
- After: https://dl-alphabetical-2--vg-macktrucks-com-au--hlxsites.hlx.page/
