### PR TITLE
Sync Main domain to update header and explore blocks

### DIFF
--- a/blocks/explore/explore.js
+++ b/blocks/explore/explore.js
@@ -105,7 +105,8 @@ function addSliderControls(contentWrapper, slidesLength) {
 }
 
 function decorateSlider(container) {
-  const tabContent = container.querySelector('#explore-trucks + .tab-content');
+  // explore trucks' slider has to be the 1st h4 element
+  const tabContent = container.querySelector('h4:first-of-type + .tab-content');
   const contentWrapper = tabContent.querySelector('.content-wrapper');
   const sliderWrapper = contentWrapper.children[0]; // div with data-align center
 

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -4,6 +4,15 @@ import {
 import { createOptimizedPicture, decorateIcons } from '../../scripts/lib-franklin.js';
 import { getAllElWithChildren } from '../../scripts/scripts.js';
 
+// domain examples: '.com', 'nicaragua.com', '.com.pa', '.ca'
+const loginDomains = ['.com'];
+const searchDomains = ['.com'];
+const url = new URL(window.location.href);
+const isDev = url.host.match('localhost') || url.host.match('hlx.(page|live)');
+const isSearchDomain = !isDev
+  && searchDomains.some((domain) => url.host.endsWith(`macktrucks${domain}`));
+const isLoginDomain = loginDomains.some((domain) => url.host.endsWith(`macktrucks${domain}`));
+
 const blockClass = 'header';
 
 const desktopMQ = window.matchMedia('(min-width: 1200px)');
@@ -114,8 +123,9 @@ const mobileActions = () => {
 
   const actions = document.createRange().createContextualFragment(`
     <a
-      href="/search"
-      aria-label="${searchLabel}"
+      href="${isSearchDomain ? '/search' : '#'}"
+      ${isSearchDomain ? `aria-label="${searchLabel}"` : 'aria-hidden="true"'}
+      ${isSearchDomain ? '' : 'style="visibility: hidden;"'}
       class="${blockClass}__search-button ${blockClass}__action-link ${blockClass}__link"
     >
       <span class="icon icon-search" aria-hidden="true"></span>
@@ -473,9 +483,11 @@ export default async function decorate(block) {
   };
 
   // add actions for search
-  navContent.querySelector(`.${blockClass}__search-button`).addEventListener('click', () => {
-    window.location.href = '/search';
-  });
+  if (isSearchDomain) {
+    navContent.querySelector(`.${blockClass}__search-button`).addEventListener('click', () => {
+      window.location.href = '/search';
+    });
+  }
 
   // add action for hamburger
   navContent.querySelector(`.${blockClass}__hamburger-menu`).addEventListener('click', () => {
@@ -538,6 +550,9 @@ export default async function decorate(block) {
     const actionsLinksDesktopMountPoint = document.querySelector('.header__actions');
     const headerMainNav = document.querySelector('.header__main-links'); // mobile actions links mount point
     const buttonsWithoutIcons = getAllElWithChildren([...actionsLinks.querySelectorAll('a')], '.icon', true);
+    const loginLink = actionsLinks.querySelector('.header__action-item a[href*="login"]');
+
+    if (!isLoginDomain) loginLink.parentElement.style.display = 'none';
 
     if (isDesktop) {
       actionsLinksDesktopMountPoint.append(actionsLinks);

--- a/mack-news/feed.xml
+++ b/mack-news/feed.xml
@@ -2,7 +2,7 @@
 <feed xmlns="http://www.w3.org/2005/Atom">
     <id>https://www.macktrucks.com/mack-news/</id>
     <title>Mack News</title>
-    <updated>2023-11-15T00:00:00.000Z</updated>
+    <updated>2023-11-21T00:00:00.000Z</updated>
     <generator>AEM Project Franklin News feed generator (GitHub action)</generator>
     <link rel="alternate" href="https://www.macktrucks.com/mack-news/"/>
     <subtitle>Get the latest news from Mack® Trucks and see how we are taking our Born Ready semi truck line to the next level with new innovations and technology.</subtitle>
@@ -2712,5 +2712,13 @@
         <updated>2023-11-15T00:00:00.000Z</updated>
         <content type="html"><![CDATA[GREENSBORO, NC (Nov. 15, 2023) – Mack Trucks today announced that members of the United Auto Workers union ratified a new five-year collective bargaining agreement with the company covering about 3,900 employees at facilities in Pennsylvania, Maryland and Florida.]]></content>
         <published>2023-11-15T00:00:00.000Z</published>
+    </entry>
+    <entry>
+        <title type="html"><![CDATA[Mack Trucks Adds Two New Full-Service EV Infrastructure Partners to its Turnkey Solutions Program | Mack Trucks]]></title>
+        <id>https://www.macktrucks.com/mack-news/2023/mack-trucks-adds-two-new-full-service-ev-infrastructure-partners-to-its-turnkey-solutions-program</id>
+        <link href="https://www.macktrucks.com/mack-news/2023/mack-trucks-adds-two-new-full-service-ev-infrastructure-partners-to-its-turnkey-solutions-program"/>
+        <updated>2023-11-21T00:00:00.000Z</updated>
+        <content type="html"><![CDATA[GREENSBORO, N.C. (Nov. 20, 2023) – Mack Trucks announced today that it expanded its comprehensive Turnkey Solutions program for Mack® battery-electric vehicle (BEV) customers with the addition of two new full-service partners, InCharge Energy and Blink Charging.]]></content>
+        <published>2023-11-21T00:00:00.000Z</published>
     </entry>
 </feed>


### PR DESCRIPTION
# Update

Sync Main `.com` domain to update _Header_ and _Explore_ blocks

### Header

Hide search and/or Login in other domains than the main one (by now)

### Explore

Make the Explore-trucks tab able to be in any language, but it has to be the 1st H4

#

Test URLs:
- Before: https://main--vg-macktrucks-com-au--hlxsites.hlx.page/
- After: https://develop--vg-macktrucks-com-au--hlxsites.hlx.page/
