### PR TITLE
temporary workaround to let GTM load

### DIFF
--- a/scripts/delayed.js
+++ b/scripts/delayed.js
@@ -15,7 +15,7 @@ const isPerformanceAllowed = cookieSetting.includes(COOKIES.performance);
 const isSocialAllowed = cookieSetting.includes(COOKIES.social);
 
 if (isPerformanceAllowed) {
-  loadGoogleTagManager();
+  // loadGoogleTagManager(); // FIXME - this is a workaround for the delayed loading of GTM
   loadHotjar();
 }
 
@@ -24,7 +24,7 @@ if (isSocialAllowed) {
 }
 
 // add more delayed functionality here
-
+loadGoogleTagManager(); // FIXME - this is a workaround for the delayed loading of GTM
 // Prevent the cookie banner from loading when running in library
 if (!window.location.pathname.includes('srcdoc')
   && !['localhost', 'hlx.page'].some((url) => window.location.host.includes(url))) {


### PR DESCRIPTION
# Temporary fix

To let OneTrust work as expected, we need this temporary action to let OneTrust do its scan. after client confirmation, we can undo this PR to its previous state

Test URLs:
- Before: https://main--vg-macktrucks-com-au--hlxsites.hlx.page/
- After: https://7-temp-action--vg-macktrucks-com-au--hlxsites.hlx.page/
